### PR TITLE
feat: mark option.name as omitempty

### DIFF
--- a/property.go
+++ b/property.go
@@ -123,7 +123,7 @@ func (p MultiSelectProperty) GetType() PropertyType {
 
 type Option struct {
 	ID    PropertyID `json:"id,omitempty"`
-	Name  string     `json:"name"`
+	Name  string     `json:"name,omitempty"`
 	Color Color      `json:"color,omitempty"`
 }
 


### PR DESCRIPTION
We're mostly using the ID to set a property and not the name. According to the API, the name should be undefined if not set, not `""`.